### PR TITLE
* [dc2] Fix extension when not using 'filenames' parameter

### DIFF
--- a/lib/MwbExporter/Core/Helper/ZipFileExporter.php
+++ b/lib/MwbExporter/Core/Helper/ZipFileExporter.php
@@ -84,7 +84,7 @@ class ZipFileExporter
         }
         else
         {
-            $fileName   = $schemaName . '.' . $tableName . $this->saveFormat;
+            $fileName   = $schemaName . '.' . $tableName . '.' . $this->saveFormat;
         }
 
         $this->zip->addFromString($fileName, $table->display());


### PR DESCRIPTION
When not using 'filenames' parameter, the extension needs a "."
