### PR TITLE
Added a composer.json file to be used with Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "mysql-workbench-schema-exporter/mysql-workbench-schema-exporter",
+    "type": "cli",
+    "description": "MySQL Workbench Schema Exporter",
+    "keywords": ["mysql","workbench","database","doctrine","cli"],
+    "homepage": "https://github.com/johmue/mysql-workbench-schema-exporter",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Johannes Mueller",
+            "email": "circus2@web.de",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    }
+}


### PR DESCRIPTION
Hi,

I've added a composer.json file so this package can be used with http://packagist.org/. As I use your repo in my Symfony2 framework which has migrated to use Packagist and it's really helpful at maintaining your vendors etc. Check it out if you haven't already, it's a really cool open source package solution for PHP.

At the moment I've set up a http://packagist.org/packages/mysql-workbench-schema-exporter/mysql-workbench-schema-exporter and pointed it to my brand on my fork as a test (as you need the composer.json file to be in the root dir). I hope you don't mind. 

Once you have accepted this pull request I will ask the Packagist to either delete this repo I've create so you can create your own or this repo can be updated  to point to your master branch and I can add yourself as a maintainer so you have the power to update it etc.

I'm flexible on how this can proceed after the merged, I hope you dont feel like I've crossed a boundary here.

Looking forward to your comments.

Thanks,
Marc
