### PR TITLE
Pluralizes relationships.

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Column.php
@@ -80,7 +80,7 @@ class Column extends BaseColumn
                 if (!isset($values[static::RELATION_ONE_TO_MANY])) {
                     $values[static::RELATION_ONE_TO_MANY] = array();
                 }
-                $values[static::RELATION_ONE_TO_MANY][$relationName] = array(
+                $values[static::RELATION_ONE_TO_MANY][Pluralizer::pluralize($relationName)] = array(
                     'targetEntity'  => $targetEntityFQCN,
                     'mappedBy'      => lcfirst($mappedBy),
                     'cascade'       => $formatter->getCascadeOption($foreign->parseComment('cascade')),

--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
@@ -108,7 +108,7 @@ class Table extends BaseTable
                 'cascade'      => $formatter->getCascadeOption($relation['reference']->parseComment('cascade')),
                 'fetch'        => $formatter->getFetchOption($relation['reference']->parseComment('fetch')),
             );
-            $relationName = $relation['refTable']->getRawTableName();
+            $relationName = Pluralizer::pluralize($relation['refTable']->getRawTableName());
             // if this is the owning side, also output the JoinTable Annotation
             // otherwise use "mappedBy" feature
             if ($isOwningSide) {


### PR DESCRIPTION
This allows more natural sounding names, as Doctrine takes care of the
reverse pluralisation when building entities from the metadata.  For
example,  if we have a one to many relationship between two tables
"blog" and "post" (where one blog has many posts), this patch causes
doctrine to generate the methods getPosts(), addPost(), removePost().
Previously the first method would have been getPost().

Additional support has been added to do the same for many to many relationships.
