### PR TITLE
Mark tables with extra columns as not many to many.

### DIFF
--- a/lib/MwbExporter/Model/Table.php
+++ b/lib/MwbExporter/Model/Table.php
@@ -231,6 +231,11 @@ class Table extends Base
                     $this->isM2M = false;
                     break;
 
+                // user hinted that this is a m2m table
+                case ("true" === $this->parseComment('m2m')):
+                    $this->isM2M = true;
+                    break;
+
                 // contains 2 foreign keys
                 case (2 !== count($fkeys = $this->getForeignKeys())):
                     $this->isM2M = false;
@@ -244,6 +249,11 @@ class Table extends Base
                 // foreign tables is not many to many
                 case $deep && $fkeys[0]->getReferencedTable()->isManyToMany(false):
                 case $deep && $fkeys[1]->getReferencedTable()->isManyToMany(false):
+                    $this->isM2M = false;
+                    break;
+
+                // has more columns than id + 2 x key columnns, is not many to many
+                case (3 !== count($this->getColumns())):
                     $this->isM2M = false;
                     break;
 


### PR DESCRIPTION
When a many to many table has additional properties, then the correct
doctrine approach is to mark it as a separate entity and use one to
many/many to one relationships for it.  This modifies the many to many
detection to exclude tables which have more than three columns (one for
id + one for each foreign key).

The comment for auto detection disabling has been retained and a new one
for forcing m2m to be enabled (same comment format, but setting to true)
has been added.
