### PR TITLE
Prevent Doctrine2 YAML from writing out M2M tables.

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
@@ -37,17 +37,21 @@ class Table extends BaseTable
 {
     public function writeTable(WriterInterface $writer)
     {
-        if (!$this->isExternal()) {
-            $writer
-                ->open($this->getTableFileName())
-                ->write($this->asYAML())
-                ->close()
-            ;
-
-            return self::WRITE_OK;
+        switch (true) {
+            case ($this->isExternal()): 
+                return self::WRITE_EXTERNAL;
+                break;
+            case ($this->isManyToMany()):
+                return self::WRITE_M2M;
+                break;
         }
 
-        return self::WRITE_EXTERNAL;
+        $writer
+            ->open($this->getTableFileName())
+            ->write($this->asYAML())
+            ->close();
+
+        return self::WRITE_OK;
     }
 
     public function asYAML()


### PR DESCRIPTION
Amends writeTable() so that it does not write out M2M tables.  This
problem appears to affect most writeTable functions and a better
solution would be push the logic of whether to write (i.e. external
tables and m2m tables) should be in the base table, leaving the actual
writing to the children.  If there is interest, I am happy to provide a
fix along those lines.
