### PR TITLE
Unidirectional foreign key parameter is ignored on owning side of One-to-One association.

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -500,7 +500,12 @@ class Table extends BaseTable
                     ->write('')
                 ;
             } else {
+
                 $this->getDocument()->addLog('  Relation considered as "1 <=> 1"');
+
+                if ($this->isForeignKeyIgnored($local)) {
+                    continue;
+                }
 
                 $annotationOptions['inversedBy'] = $annotationOptions['mappedBy'];
                 $annotationOptions['mappedBy'] = null;


### PR DESCRIPTION
When a one-to-one, unidirectional association is needed for Doctrine2 annotations, a one-to-one bidirectional association is always created, regardless of setting unidirectional parameter for the foreign key on the owning side.
