### PR TITLE
Get correct namespace for comment tag prefixes in doctrine1-yaml formatt...

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine1/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine1/Formatter.php
@@ -42,10 +42,11 @@ abstract class Formatter extends BaseFormatter
 
     /**
      * (non-PHPdoc)
-     * @see \MwbExporter\Formatter\Formatter::getCommentParserIdentifierPrefix()
+     * @see \MwbExporter\Formatter\Formatter::getCommentTagPrefixes()
      */
-    public function getCommentParserIdentifierPrefix()
+    public function getCommentTagPrefixes()
     {
-        return 'd|doctrine';
+        $prefixes = parent::getCommentTagPrefixes();
+        return array_merge($prefixes, array('d|doctrine'));
     }
 }


### PR DESCRIPTION
I found that Doctrine1 Formatter has method that does not exist in the parent class. Method is not invoked so entire script searches for comments in namespace MwbExporter instead of "d" or "doctrine".
