### PR TITLE
Added addIdProperty config for ExtJS 4 models.

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ exactly the same as Doctrine 2.0 Annotation with the following addons.
     Generate ajax proxy.
 
     Default is `true`.
+    
+  * `addIdProperty`
+    
+    Add the primary key of a table as the model's idProperty.
+    ([Reference](http://docs.sencha.com/extjs/4.2.3/#!/api/Ext.data.Model-cfg-idProperty))
+    
+    Default is `false`.
 
 ### Node
 
@@ -540,7 +547,7 @@ Sample usage:
     php bin/mysql-workbench-schema-export --export=doctrine1-yaml example/data/test.mwb ./generated
     php bin/mysql-workbench-schema-export --zip example/data/test.mwb
 
-Sample export paramaters (JSON) for doctrine2-annotation:
+Sample export parameters (JSON) for doctrine2-annotation:
 
     {
         "export": "doctrine2-annotation",

--- a/lib/MwbExporter/Formatter/Sencha/ExtJS4/Formatter.php
+++ b/lib/MwbExporter/Formatter/Sencha/ExtJS4/Formatter.php
@@ -35,6 +35,7 @@ class Formatter extends BaseFormatter
 {
     const CFG_GENERATE_VALIDATION    = 'generateValidation';
     const CFG_GENERATE_PROXY         = 'generateProxy';
+    const CFG_ADD_IDPROPERTY         = 'addIdProperty';
 
     /**
      * (non-PHPdoc)
@@ -49,6 +50,7 @@ class Formatter extends BaseFormatter
             static::CFG_PARENT_CLASS         => 'Ext.data.Model',
             static::CFG_GENERATE_VALIDATION  => true,
             static::CFG_GENERATE_PROXY       => true,
+            static::CFG_ADD_IDPROPERTY       => false,
         ));
     }
 

--- a/lib/MwbExporter/Formatter/Sencha/ExtJS4/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Sencha/ExtJS4/Model/Table.php
@@ -78,6 +78,14 @@ class Table extends BaseTable
     public function asModel()
     {
         $result = array('extend' => $this->getParentClass());
+
+        if ($this->getConfig()->get(Formatter::CFG_ADD_IDPROPERTY)) {
+            $primaryKeyColumnName = $this->getPrimaryKey();
+            if ($primaryKeyColumnName) {
+                $result['idProperty'] = $primaryKeyColumnName;
+            }
+        }
+
         if (count($data = $this->getUses())) {
             $result['uses'] = $data;
         }
@@ -233,6 +241,22 @@ class Table extends BaseTable
         }
 
         return $result;
+    }
+
+    /**
+     * Get the column name of the column that is the primary key. Returns null if no primary key is defined.
+     *
+     * @return string|null
+     */
+    protected function getPrimaryKey()
+    {
+        foreach ($this->getColumns() as $column) {
+            if ($column->isPrimary()) {
+                return $column->getColumnName();
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
ExtJS 4 allows model classes to specify an idProperty, which should contain the name of the field that holds the unique id for that model (see the [ExtJs docs](http://docs.sencha.com/extjs/4.2.3/#!/api/Ext.data.Model-cfg-idProperty) for more information. As I found myself readding this property several time to my generated classes I reckoned it would be better to incorporate it into the exporter itself. I disabled idProperty generation by default to preserve backwards compatibility.
