### PR TITLE
Add config for generated value strategy in Doctrine 2 formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Common Setup Options for Doctrine 2.0:
 
     Default is `auto`.
 
+  * `generatedValueStrategy`
+    
+    The stragety for auto-generated values.
+
+    Default is `auto`.
+
 #### Doctrine 2.0 YAML Schema
 
 ##### Setup Options

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -44,7 +44,7 @@ class Column extends BaseColumn
                         ' * '.$this->getTable()->getAnnotation('Id'))
                 ->write(' * '.$this->getTable()->getAnnotation('Column', $this->asAnnotation()))
                 ->writeIf($this->isAutoIncrement(),
-                        ' * '.$this->getTable()->getAnnotation('GeneratedValue', array('strategy' => 'AUTO')))
+                        ' * '.$this->getTable()->getAnnotation('GeneratedValue', array('strategy' => strtoupper($this->getConfig()->get(Formatter::CFG_GENERATED_VALUE_STRATEGY)))))
                 ->write(' */')
                 ->write('protected $'.$this->getColumnName().';')
                 ->write('')

--- a/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
@@ -39,9 +39,16 @@ abstract class Formatter extends BaseFormatter
     const CFG_SKIP_COLUMN_WITH_RELATION      = 'skipColumnWithRelation';
     const CFG_RELATED_VAR_NAME_FORMAT        = 'relatedVarNameFormat';
     const CFG_NULLABLE_ATTRIBUTE             = 'nullableAttribute';
+    const CFG_GENERATED_VALUE_STRATEGY       = 'generatedValueStrategy';
 
     const NULLABLE_AUTO                      = 'auto';
     const NULLABLE_ALWAYS                    = 'always';
+
+    const GENERATED_VALUE_AUTO               = 'auto';
+    const GENERATED_VALUE_IDENTITY           = 'identity';
+    const GENERATED_VALUE_SEQUENCE           = 'sequence';
+    const GENERATED_VALUE_TABLE              = 'table';
+    const GENERATED_VALUE_NONE               = 'none';
 
     protected function init()
     {
@@ -54,9 +61,17 @@ abstract class Formatter extends BaseFormatter
             static::CFG_SKIP_COLUMN_WITH_RELATION     => false,
             static::CFG_RELATED_VAR_NAME_FORMAT       => '%name%%related%',
             static::CFG_NULLABLE_ATTRIBUTE            => static::NULLABLE_AUTO,
+            static::CFG_GENERATED_VALUE_STRATEGY      => static::GENERATED_VALUE_AUTO,
         ));
         $this->addValidators(array(
             static::CFG_NULLABLE_ATTRIBUTE            => new ChoiceValidator(array(static::NULLABLE_AUTO, static::NULLABLE_ALWAYS)),
+            static::CFG_GENERATED_VALUE_STRATEGY      => new ChoiceValidator(array(
+                static::GENERATED_VALUE_AUTO,
+                static::GENERATED_VALUE_IDENTITY,
+                static::GENERATED_VALUE_SEQUENCE,
+                static::GENERATED_VALUE_TABLE,
+                static::GENERATED_VALUE_NONE,
+            )),
         ));
     }
 

--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Column.php
@@ -50,7 +50,7 @@ class Column extends BaseColumn
             $values['unsigned'] = true;
         }
         if ($this->isAutoIncrement()) {
-            $values['generator'] = array('strategy' => 'AUTO');
+            $values['generator'] = array('strategy' => strtoupper($this->getConfig()->get(Formatter::CFG_GENERATED_VALUE_STRATEGY)));
         }
 
         return $values;


### PR DESCRIPTION
Hello johmue,

thanks for this great job that makes me save a lot of time. This is now part of my workflow.
I have found that the user configuration about strategy is not used and is actually hard coded in different schemas.
Here is my modification to make it work with Doctrine 2. I also added the IDENTITY strategy that I needed for my pgsql project.
