### PR TITLE
Doctrine 2 anotations : one to one bidirectional cross dependance

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -498,7 +498,6 @@ class Table extends BaseTable
                 $writer
                     ->write('/**')
                     ->write(' * '.$this->getAnnotation('OneToOne', $annotationOptions))
-                    ->write(' * '.$this->getJoins($local))
                     ->write(' */')
                     ->write('protected $'.lcfirst($targetEntity).';')
                     ->write('')


### PR DESCRIPTION
Hello,

as far as i can see in Doctrine doc , and specially the one-to-one bidirectional association example (http://doctrine-orm.readthedocs.org/en/latest/reference/association-mapping.html#one-to-one-bidirectional), the 2 lines I deleted are not needed. In my case, it was generating cross foreign keys in database.
