### PR TITLE
Default option for zero or empty string

### DIFF
--- a/lib/MwbExporter/Model/Column.php
+++ b/lib/MwbExporter/Model/Column.php
@@ -252,8 +252,9 @@ class Column extends Base
     public function getDefaultValue()
     {
         if (1 != $this->parameters->get('defaultValueIsNull')) {
-            if (($defaultValue = trim($this->parameters->get('defaultValue'), '\'"')) && ('NULL' != $defaultValue)) {
-                return $defaultValue;
+            $defaultValue = $this->parameters->get('defaultValue');
+            if (strlen($defaultValue) && 'NULL' != $defaultValue) {
+                return trim($defaultValue, '\'"');
             }
         }
     }


### PR DESCRIPTION
When default option is 0 (zero) or empty string ('') function `getDefaultValue()` should return 0 or '' but returns `null`. 