### PR TITLE
Fix variable casing

### DIFF
--- a/lib/MwbExporter/Model/Base.php
+++ b/lib/MwbExporter/Model/Base.php
@@ -383,15 +383,16 @@ abstract class Base
      * @param string $underscored_text
      * @return string
      */
-    public function beautify($underscored_text)
+    public function beautify($underscored_text, $pascalCase = true)
     {
         if ($this->getConfig()->get(FormatterInterface::CFG_STRIP_MULTIPLE_UNDERSCORES, false)) {
             $underscored_text = str_replace('__', '_', $underscored_text);
         }
-
-        return ucfirst(preg_replace_callback('@\_(\w)@', function($matches) {
+        $beautified = preg_replace_callback('@\_(\w)@', function($matches) {
             return ucfirst($matches[1]);
-        }, $underscored_text));
+        }, $underscored_text);
+
+        return $pascalCase ? ucfirst($beautified) : $beautified;
     }
 
     /**

--- a/lib/MwbExporter/Model/Column.php
+++ b/lib/MwbExporter/Model/Column.php
@@ -109,9 +109,9 @@ class Column extends Base
      *
      * @return string
      */
-    public function getBeautifiedColumnName()
+    public function getBeautifiedColumnName($pascalCase = true)
     {
-        return $this->beautify($this->getColumnName());
+        return $this->beautify($this->getColumnName(), $pascalCase);
     }
 
     /**


### PR DESCRIPTION
Previously, only property fields for relations used camel case. Now, all property fields are properly cased.