### PR TITLE
fix bug - Model\Base->singularize() method is calling the pluralize method

### DIFF
--- a/lib/Model/Base.php
+++ b/lib/Model/Base.php
@@ -401,7 +401,7 @@ abstract class Base
      */
     public function singularize($word)
     {
-        return $this->getFormatter()->getInflector()->pluralize($word);
+        return $this->getFormatter()->getInflector()->singularize($word);
     }
 
     /**


### PR DESCRIPTION
It looks like with the update from 07/20 the singularize($word) method has been changed to call the pluralize($word) method from the Doctrine Inflector.